### PR TITLE
fix gta-sa in-air vehicle steering (pitch/yaw/roll)

### DIFF
--- a/FramerateVigilante/FramerateVigilante.cpp
+++ b/FramerateVigilante/FramerateVigilante.cpp
@@ -4,6 +4,7 @@
 #include "CWorld.h"
 #include "CTimer.h"
 #include "CRunningScript.h"
+#include <cmath>
 
 using namespace plugin;
 using namespace injector;
@@ -25,6 +26,13 @@ public:
 	static inline int _lastFpsLimit;
 	static inline int _refreshRate;
 	static inline bool _autoLimitFPS;
+
+	// In-air vehicle steering sensitivity: ms_fTimeStep scaler = 60 / AirSteeringFPS (default 60)
+	static inline int airSteeringFPS = 60;
+	static inline float airSteeringScale = 60.0f / 50.0f;
+
+	// Ground angular velocity damping: reference FPS for per-second rate (default 60)
+	static inline int groundAngDampFPS = 60;
 
 	union {
 		int _isOnFlagsInt;
@@ -59,6 +67,19 @@ public:
 			void operator()(reg_pack& regs)
 			{
 				asm_fld(CTimer::ms_fTimeStep / magic);
+			}
+		};
+
+		// In-air vehicle steering sensitivity scaler.
+		// Multiplies ms_fTimeStep by (60 / AirSteeringFPS) to match
+		// the configured FPS baseline at any actual framerate.
+
+		struct AirSteerScaledFLD
+		{
+			void operator()(reg_pack& regs)
+			{
+				float f = CTimer::ms_fTimeStep * airSteeringScale;
+				asm_fld(f);
 			}
 		};
 
@@ -112,6 +133,22 @@ public:
 
 			_autoLimitFPS = ini.ReadInteger("Settings", "AutoLimitFPS", 0);
 
+			// In-air vehicle steering reference FPS (default 60, range 30-100)
+			{
+				int asFPS = ini.ReadInteger("Settings", "AirSteeringFPS", 60);
+				if (asFPS < 30) asFPS = 30;
+				if (asFPS > 100) asFPS = 100;
+				airSteeringFPS = asFPS;
+				airSteeringScale = 60.0f / (float)asFPS;
+			}
+
+			// Ground angular velocity damping reference FPS (default 60, range 30-100)
+			{
+				int gdFPS = ini.ReadInteger("Settings", "GroundAngDampFPS", 60);
+				if (gdFPS < 30) gdFPS = 30;
+				if (gdFPS > 100) gdFPS = 100;
+				groundAngDampFPS = gdFPS;
+			}
 
 			struct AimingRifleWalkFix
 			{
@@ -447,6 +484,92 @@ public:
 					regs.eax = *(uint32_t*)(regs.esp + 0xB0 - 0x90 + 0x4); //mov     eax, [esp+0B0h+out_result.y]
 				}
 			}; MakeInline<PedPushCarForce>(0x549652, 0x549652 + 8);
+
+
+			// ================================================================
+			// In-Air Vehicle Steering Framerate Fix (pitch / yaw / roll)
+			// Multiplies ms_fTimeStep by airSteeringScale = 60 / AirSteeringFPS
+			// so per-second torque matches the configured FPS baseline at any
+			// actual framerate. Combined with GroundAngDampFPS fix below,
+			// this makes vehicle angular physics truly framerate-independent.
+			// ================================================================
+
+			// --- Pitch (Up/Down) and Yaw (Space + A/D) in CAutomobile::ProcessAI ---
+
+			MakeInline<AirSteerScaledFLD>(0x6B515B, 0x6B515B + 6); // fld ms_fTimeStep → pitch torque
+			MakeInline<AirSteerScaledFLD>(0x6B4FED, 0x6B4FED + 6); // fld ms_fTimeStep → yaw (handbrake path)
+			MakeInline<AirSteerScaledFLD>(0x6B508D, 0x6B508D + 6); // fld ms_fTimeStep → yaw (accelerate path)
+
+
+			// --- Roll (A/D without handbrake) in CAutomobile::ProcessControlInputs ---
+			// Only affects steering when all wheels off ground (in the air).
+			// On ground, original ms_fTimeStep is used (already framerate-independent).
+
+			struct SteerAngleAirFixA
+			{
+				void operator()(reg_pack& regs)
+				{
+					CAutomobile* automobile = (CAutomobile*)regs.esi;
+					float f = automobile->GetAllWheelsOffGround() ? CTimer::ms_fTimeStep * airSteeringScale : CTimer::ms_fTimeStep;
+					regs.ecx = *(uint32_t*)&f;
+				}
+			}; MakeInline<SteerAngleAirFixA>(0x6AD831, 0x6AD831 + 6);
+
+			struct SteerAngleAirFixB
+			{
+				void operator()(reg_pack& regs)
+				{
+					CAutomobile* automobile = (CAutomobile*)regs.esi;
+					float f = automobile->GetAllWheelsOffGround() ? CTimer::ms_fTimeStep * airSteeringScale : CTimer::ms_fTimeStep;
+					regs.eax = *(uint32_t*)&f;
+				}
+			}; MakeInline<SteerAngleAirFixB>(0x6AD8F0, 0x6AD8F0 + 5);
+
+			// Steering return damping (pow-based decay), in-air only
+			struct SteerAngleDampFix
+			{
+				void operator()(reg_pack& regs)
+				{
+					CAutomobile* automobile = (CAutomobile*)regs.esi;
+					float f = automobile->GetAllWheelsOffGround() ? CTimer::ms_fTimeStep * airSteeringScale : CTimer::ms_fTimeStep;
+					asm_fld(f);
+				}
+			}; MakeInline<SteerAngleDampFix>(0x6AD8D7, 0x6AD8D7 + 6);
+
+
+			// --- Wheel rotation physics (affects in-air spin / body torque) ---
+
+			// CVehicle::ProcessWheelRotation: replaces fdiv [esp+arg_C] and fchs
+			struct ProcessWheelRotationFix
+			{
+				void operator()(reg_pack& regs)
+				{
+					float arg_C = *(float*)(regs.esp + 0x10);
+					float newArg = arg_C * CTimer::ms_fTimeStep * airSteeringScale;
+					asm_fdiv(newArg);
+					asm_fmul(-1.0f);  // replaces fchs that was at 0x6D125C
+				}
+			}; MakeInline<ProcessWheelRotationFix>(0x6D1258, 0x6D1258 + 6);
+
+			// ================================================================
+			// Ground Angular Velocity Damping Fix (ApplyAirResistance Branch B)
+			// Replaces fixed-per-frame fmul 0.99 with pow(0.99, ms_fTimeStep *
+			// GroundAngDampFPS/50) so per-second damping rate stays constant
+			// regardless of actual framerate. Fixes countersteering difficulty
+			// at high FPS during drifting.
+			// ================================================================
+
+			struct AirResistanceAngDampFix
+			{
+				void operator()(reg_pack& regs)
+				{
+					float damp = powf(0.99f, CTimer::ms_fTimeStep * (groundAngDampFPS / 50.0f));
+					asm_fmul(damp);
+				}
+			}; MakeInline<AirResistanceAngDampFix>(0x544D2C, 0x544D2C + 6); // angVel.x
+			MakeInline<AirResistanceAngDampFix>(0x544D38, 0x544D38 + 6); // angVel.y
+			MakeInline<AirResistanceAngDampFix>(0x544D44, 0x544D44 + 6); // angVel.z
+
 		#endif
 
 		#if defined(GTASA)


### PR DESCRIPTION
## Background

This issue has been bothering me for more than 10 years. I used to be an avid
SA:MP player, particularly into racing, stunt maps, and cruising around in an
Infernus. As SA:MP's default FPS settled around 95-100, I noticed that in-air
vehicle control — pitching the nose down/up during jumps, rolling at speed,
correcting yaw mid-air — became nearly impossible. Worse, countersteering
during drifts at high FPS became sluggish and unresponsive. I had to resort
to `/fpslimit 60` to get a reasonable balance between visual smoothness and
usable vehicle handling.

This is critical for multiplayer modes like deathmatch race servers, where
precise mid-air rotation and responsive drifting at 60 FPS are integral to
competitive play. For singleplayer it may go unnoticed, but for the racing
and stunting community still active on multiplayer, this fix restores that
crisp, predictable feel.

## Problem

Two separate issues compound at high framerates:

1. Weakened in-air steering — air pitch/yaw/roll torque is multiplied by
CTimer::ms_fTimeStep, which shrinks per-frame at higher FPS.
CPhysical::ApplyAirResistance damps angular velocity between every frame,
so the smaller torque impulses at high FPS are eaten by damping before they
can accumulate meaningful rotation.

2. Excessive angular velocity damping — ApplyAirResistance forces all
vehicles into Branch B (entity type 2 check at 0x00544C5E), which applies a
fixed 0.99 multiplier to angular velocity every frame with no timestep
scaling whatsoever. At 30 FPS this loses 26% of yaw per second; at 100 FPS
it loses 63%. This is the root cause of countersteering becoming
unresponsive during drifts at high framerates.

## Root Cause

The air steering torques themselves were designed framerate-independent by R*
(FPS × ms_fTimeStep = 50.0, constant per second). The real culprit is the
angular damping in ApplyAirResistance Branch B (0x00544D2C/38/44), which
applies angVel *= 0.99 per frame unconditionally — no ms_fTimeStep, no pow(),
just a flat multiplier that applies more often at higher FPS.

 | FPS | Yaw retained after 1 sec | Yaw lost |
 | --- | ------------------------ | -------- |
 | 30  | 0.99^30 = 74%            | 26%      |
 | 60  | 0.99^60 = 55%            | 45%      |
 | 100 | 0.99^100 = 37%           | 63%      |
 | 120 | 0.99^120 = 30%           | 70%      |

## Fix

Angular velocity damping — replace the fixed fmul 0.99 at three addresses in
ApplyAirResistance with a timestep-scaled exponential:

  angVel *= pow(0.99, ms_fTimeStep × (GroundAngDampFPS / 50))

This keeps the per-second damping rate constant at any actual framerate,
matching the configured baseline.

Air steering — multiply ms_fTimeStep by a scale factor (60 / AirSteeringFPS)
instead of substituting a baked value. Combined with the damping fix above,
per-second torque is now constant at all framerates.

Ground steering — ProcessControlInputs roll/interpolation patches (0x6AD831,
0x6AD8F0, 0x6AD8D7) only activate when all wheels are off ground
(GetAllWheelsOffGround flag); on the ground they fall back to original
ms_fTimeStep, which was already framerate-independent.

```ini
[Settings]
FPSlimit = 0
RefreshRate = 0
AutoLimitFPS = 0
AirSteeringFPS = 60      ; range 30-100, default 60 — air pitch/yaw/roll
GroundAngDampFPS = 60    ; range 30-100, default 60 — drift/yaw damping
```

- 30 = very responsive in-air, easy drifting (matches original 30 FPS feel)
- 60 = balanced and predictable, matching MTA:SA DM race server feel (recommended)
- 100 = subtle air control, firmer yaw resistance

## Affected Addresses

| Address  | Function             | Control                         | Change                               |
| -------- | -------------------- | ------------------------------- | ------------------------------------ |
| 0x6B515B | ProcessAI            | pitch (up/down)                 | fld ms_fTimeStep × scale             |
| 0x6B4FED | ProcessAI            | yaw (handbrake + A/D)           | fld ms_fTimeStep × scale             |
| 0x6B508D | ProcessAI            | yaw (accelerate + A/D)          | fld ms_fTimeStep × scale             |
| 0x6AD831 | ProcessControlInputs | roll interp (in-air only)       | mov ecx, ms_fTimeStep × scale        |
| 0x6AD8F0 | ProcessControlInputs | roll interp alt (in-air only)   | mov eax, ms_fTimeStep × scale        |
| 0x6AD8D7 | ProcessControlInputs | roll return decay (in-air only) | fld ms_fTimeStep × scale             |
| 0x6D1258 | ProcessWheelRotation | wheel spin -> body torque       | fdiv arg / (ms_fTimeStep × scale)    |
| 0x544D2C | ApplyAirResistance   | angVel.x damping                | fmul pow(0.99, ms_fTimeStep × scale) |
| 0x544D38 | ApplyAirResistance   | angVel.y damping                | same                                 |
| 0x544D44 | ApplyAirResistance   | angVel.z (yaw) damping          | same                                 |

Ground steering is preserved exactly as original. Planes and helicopters are
unaffected.